### PR TITLE
Apply UTF-8 encoding to JavaCompile tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,3 +59,7 @@ task cleanTestDb {
 }
 
 clean.dependsOn cleanTestDb
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+}


### PR DESCRIPTION
## Summary
- enforce UTF-8 encoding for all JavaCompile tasks

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844352b67e88328aff716d373898422