### PR TITLE
Run PDF generation on worker thread

### DIFF
--- a/src/main/java/com/caremonitor/view/HealthHistoryView.java
+++ b/src/main/java/com/caremonitor/view/HealthHistoryView.java
@@ -509,7 +509,25 @@ public class HealthHistoryView {
             if (!filePath.toLowerCase().endsWith(".pdf")) {
                 filePath += ".pdf";
             }
-            generatePDF(filePath, selectedPatient);
+
+            downloadPdfButton.setEnabled(false);
+            downloadPdfButton.setText("Generating...");
+
+            SwingWorker<Void, Void> worker = new SwingWorker<Void, Void>() {
+                @Override
+                protected Void doInBackground() {
+                    generatePDF(filePath, selectedPatient);
+                    return null;
+                }
+
+                @Override
+                protected void done() {
+                    downloadPdfButton.setEnabled(true);
+                    downloadPdfButton.setText("Download PDF");
+                }
+            };
+
+            worker.execute();
         }
     }
 


### PR DESCRIPTION
## Summary
- keep the UI responsive when exporting PDFs
- disable the Download PDF button while generating the report

## Testing
- `bash gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844352eca8883289efbebf4157995fd