### PR TITLE
Refactor PDF generation in HealthHistoryView

### DIFF
--- a/src/main/java/com/caremonitor/view/HealthHistoryView.java
+++ b/src/main/java/com/caremonitor/view/HealthHistoryView.java
@@ -533,8 +533,9 @@ public class HealthHistoryView {
     }
 
     private void generatePDF(String filePath, Patient patient) {
-        try (Document document = new Document();
-             FileOutputStream fos = new FileOutputStream(filePath)) {
+        Document document = null;
+        try (FileOutputStream fos = new FileOutputStream(filePath)) {
+            document = new Document();
             PdfWriter.getInstance(document, fos);
             document.open();
             
@@ -588,6 +589,10 @@ public class HealthHistoryView {
                 "Error generating PDF: " + e.getMessage(),
                 "Error",
                 JOptionPane.ERROR_MESSAGE);
+        } finally {
+            if (document != null) {
+                document.close();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- manage only `FileOutputStream` in the try-with-resources block
- explicitly open and close the iText `Document`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684438abded883289e136956a1c6caa4