### PR TITLE
Restrict empty PDF report generation

### DIFF
--- a/src/main/java/com/caremonitor/view/HealthHistoryView.java
+++ b/src/main/java/com/caremonitor/view/HealthHistoryView.java
@@ -490,11 +490,27 @@ public class HealthHistoryView {
         }
 
         Patient selectedPatient = patients.get(selectedIndex - 1);
-        
+
+        LocalDateTime fromDateTime = ((Date) fromDateSpinner.getValue()).toInstant()
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+        LocalDateTime toDateTime = ((Date) toDateSpinner.getValue()).toInstant()
+                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+
+        List<HealthData> reportData = healthDataController.getHealthDataByPatientIdAndDateRange(
+                selectedPatient.getId(), fromDateTime, toDateTime);
+
+        if (reportData.isEmpty()) {
+            DialogUtil.showMessage(mainPanel,
+                "No data available for the selected period.",
+                "No Data",
+                JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
         JFileChooser fileChooser = new JFileChooser();
         fileChooser.setDialogTitle("Save PDF Report");
         fileChooser.setSelectedFile(new java.io.File("health_report_" + selectedPatient.getName().replaceAll("\\s+", "_") + ".pdf"));
-        
+
         int userSelection = fileChooser.showSaveDialog(mainPanel);
         if (userSelection == JFileChooser.APPROVE_OPTION) {
             String filePath = fileChooser.getSelectedFile().getAbsolutePath();
@@ -511,10 +527,6 @@ public class HealthHistoryView {
 
                 @Override
                 protected Void doInBackground() {
-                    LocalDateTime fromDateTime = ((Date) fromDateSpinner.getValue()).toInstant()
-                            .atZone(ZoneId.systemDefault()).toLocalDateTime();
-                    LocalDateTime toDateTime = ((Date) toDateSpinner.getValue()).toInstant()
-                            .atZone(ZoneId.systemDefault()).toLocalDateTime();
                     try {
                         healthDataController.generatePDFReport(finalFilePath, selectedPatient, fromDateTime, toDateTime);
                     } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- stop report generation when there's no data for the selected period
- notify the user via dialog instead of generating an empty PDF

## Testing
- `bash ./gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684452a006388328b6ee4817e5ffadc0