### PR TITLE
Align login/register layouts

### DIFF
--- a/src/main/java/com/caremonitor/view/LoginView.java
+++ b/src/main/java/com/caremonitor/view/LoginView.java
@@ -67,11 +67,12 @@ public class LoginView extends JFrame {
     }
 
     private void setupLayout() {
-        JPanel mainPanel = new JPanel(new MigLayout("fill", "[30%][grow]", "fill"));
+        JPanel mainPanel = new JPanel(new BorderLayout());
         mainPanel.setBackground(Color.WHITE);
 
         JPanel leftPanel = new JPanel(new MigLayout("center, flowy", "[grow]", "push[]10[]push"));
         leftPanel.setBackground(UIStyles.DARK_BLUE);
+        leftPanel.setPreferredSize(new Dimension(UIStyles.AUTH_LEFT_PANEL_WIDTH, 0));
         
         JPanel logoPanel = new JPanel();
         logoPanel.setBackground(UIStyles.DARK_BLUE);
@@ -156,8 +157,8 @@ public class LoginView extends JFrame {
         
         rightPanel.add(formPanel, "align center");
         
-        mainPanel.add(leftPanel, "growy");
-        mainPanel.add(rightPanel, "grow");
+        mainPanel.add(leftPanel, BorderLayout.WEST);
+        mainPanel.add(rightPanel, BorderLayout.CENTER);
         
         setContentPane(mainPanel);
     }

--- a/src/main/java/com/caremonitor/view/RegisterView.java
+++ b/src/main/java/com/caremonitor/view/RegisterView.java
@@ -144,7 +144,7 @@ public class RegisterView extends JFrame {
         // Left Panel (Logo & Title)
         JPanel leftPanel = new JPanel(new GridBagLayout()); // Use GridBagLayout for centering
         leftPanel.setBackground(UIStyles.DARK_BLUE);
-        leftPanel.setPreferredSize(new Dimension(500, 0)); // Lebar tetap 500
+        leftPanel.setPreferredSize(new Dimension(UIStyles.AUTH_LEFT_PANEL_WIDTH, 0));
 
         JPanel logoContentPanel = new JPanel(); // Panel untuk menampung logo dan subtitle
         logoContentPanel.setBackground(UIStyles.DARK_BLUE);

--- a/src/main/java/com/caremonitor/view/theme/UIStyles.java
+++ b/src/main/java/com/caremonitor/view/theme/UIStyles.java
@@ -47,4 +47,7 @@ public final class UIStyles {
     public static final Font ARIAL_ITALIC_11 = new Font("Arial", Font.ITALIC, 11);
     public static final Font ARIAL_ITALIC_12 = new Font("Arial", Font.ITALIC, 12);
     public static final Font ARIAL_ITALIC_14 = new Font("Arial", Font.ITALIC, 14);
+
+    // Common layout constants
+    public static final int AUTH_LEFT_PANEL_WIDTH = 500;
 }


### PR DESCRIPTION
## Summary
- add `AUTH_LEFT_PANEL_WIDTH` constant in UIStyles
- use the constant for left panel width in RegisterView and LoginView
- switch LoginView to `BorderLayout` so it matches RegisterView

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684950c4678c83289a1a5fe47fbd4d4a