### PR TITLE
Improve layout consistency in auth views

### DIFF
--- a/src/main/java/com/caremonitor/view/LoginView.java
+++ b/src/main/java/com/caremonitor/view/LoginView.java
@@ -19,6 +19,9 @@ public class LoginView extends JFrame {
     private StyledTextField.StyledPasswordField passwordField;
     private PrimaryButton loginButton;
     private AuthController authController;
+
+    private static final Dimension FIELD_SIZE = new Dimension(350, 40);
+    private static final Dimension BUTTON_SIZE = new Dimension(350, 45);
     
 
     public LoginView() {
@@ -37,6 +40,13 @@ public class LoginView extends JFrame {
         emailField = new StyledTextField();
         passwordField = new StyledTextField.StyledPasswordField();
         loginButton = new PrimaryButton("Log In");
+
+        emailField.setPreferredSize(FIELD_SIZE);
+        emailField.setMaximumSize(FIELD_SIZE);
+        passwordField.setPreferredSize(FIELD_SIZE);
+        passwordField.setMaximumSize(FIELD_SIZE);
+        loginButton.setPreferredSize(BUTTON_SIZE);
+        loginButton.setMaximumSize(BUTTON_SIZE);
         
         emailField.setFont(UIStyles.ARIAL_PLAIN_14);
         emailField.setBorder(BorderFactory.createCompoundBorder(
@@ -96,12 +106,13 @@ public class LoginView extends JFrame {
         
         leftPanel.add(logoPanel);
         
-        JPanel rightPanel = new JPanel(new MigLayout("fill, insets 0", "[grow,fill]", "[grow]"));
+        JPanel rightPanel = new JPanel(new GridBagLayout());
         rightPanel.setBackground(Color.WHITE);
         
         JPanel formPanel = new JPanel(new MigLayout("wrap 1,fillx", "[grow,fill]", ""));
         formPanel.setBackground(Color.WHITE);
         formPanel.setBorder(new EmptyBorder(50, 50, 50, 50));
+        formPanel.setMaximumSize(new Dimension(400, Integer.MAX_VALUE));
         
         JLabel titleLabel = new JLabel("Log In");
         titleLabel.setFont(UIStyles.ARIAL_BOLD_32);
@@ -154,7 +165,11 @@ public class LoginView extends JFrame {
         formPanel.add(loginButton, "gaptop 30, growx");
         formPanel.add(registerPanel, "gaptop 20, align left");
         
-        rightPanel.add(formPanel, "align center");
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.anchor = GridBagConstraints.CENTER;
+        rightPanel.add(formPanel, gbc);
         
         mainPanel.add(leftPanel, "growy");
         mainPanel.add(rightPanel, "grow");

--- a/src/main/java/com/caremonitor/view/RegisterView.java
+++ b/src/main/java/com/caremonitor/view/RegisterView.java
@@ -170,7 +170,7 @@ public class RegisterView extends JFrame {
         leftPanel.add(logoContentPanel); // Tambahkan logoContentPanel ke leftPanel yang ber-GridBagLayout
 
         // Right Panel (Forms)
-        JPanel rightPanel = new JPanel(new BorderLayout()); // Gunakan BorderLayout untuk mainFormPanel
+        JPanel rightPanel = new JPanel(new GridBagLayout());
         rightPanel.setBackground(Color.WHITE);
 
         cardLayout = new CardLayout();
@@ -183,7 +183,12 @@ public class RegisterView extends JFrame {
         mainFormPanel.add(step1Panel, "step1");
         mainFormPanel.add(step2Panel, "step2");
 
-        rightPanel.add(mainFormPanel, BorderLayout.CENTER); // mainFormPanel akan mengambil seluruh ruang di rightPanel
+        mainFormPanel.setMaximumSize(new Dimension(400, Integer.MAX_VALUE));
+        GridBagConstraints gbcRight = new GridBagConstraints();
+        gbcRight.gridx = 0;
+        gbcRight.gridy = 0;
+        gbcRight.anchor = GridBagConstraints.CENTER;
+        rightPanel.add(mainFormPanel, gbcRight);
 
         mainPanel.add(leftPanel, BorderLayout.WEST);
         mainPanel.add(rightPanel, BorderLayout.CENTER);
@@ -199,7 +204,7 @@ public class RegisterView extends JFrame {
         JPanel formContentPanel = new JPanel(); // Panel to hold all form inputs
         formContentPanel.setLayout(new BoxLayout(formContentPanel, BoxLayout.Y_AXIS));
         formContentPanel.setBackground(Color.WHITE);
-        formContentPanel.setMaximumSize(new Dimension(FIELD_SIZE.width + 100, Integer.MAX_VALUE)); // Max width for form
+        formContentPanel.setMaximumSize(new Dimension(400, Integer.MAX_VALUE)); // Max width for form
 
         JLabel titleLabel = new JLabel("Register New Account");
         titleLabel.setFont(UIStyles.ARIAL_BOLD_32); // Ukuran font lebih besar
@@ -281,7 +286,7 @@ public class RegisterView extends JFrame {
     private void createStep2Panel() {
         step2Panel = new JPanel(new BorderLayout());
         step2Panel.setBackground(Color.WHITE);
-        step2Panel.setBorder(BorderFactory.createEmptyBorder(30, 50, 30, 50));
+        step2Panel.setBorder(BorderFactory.createEmptyBorder(50, 50, 50, 50));
 
         JPanel headerPanel = new JPanel(new BorderLayout());
         headerPanel.setBackground(Color.WHITE);
@@ -371,7 +376,7 @@ public class RegisterView extends JFrame {
         }
 
         JScrollPane scrollPane = new JScrollPane(caregiverPatientPanel);
-        scrollPane.setPreferredSize(new Dimension(FIELD_SIZE.width + 100, 250)); // Lebar scrollPane sesuai form
+        scrollPane.setPreferredSize(new Dimension(400, 250)); // Limit width
         scrollPane.setBorder(BorderFactory.createTitledBorder(
                 BorderFactory.createLineBorder(UIStyles.BORDER_GRAY),
                 "Select Patients",
@@ -480,7 +485,7 @@ public class RegisterView extends JFrame {
         }
 
         JScrollPane scrollPane = new JScrollPane(familyPatientPanel);
-        scrollPane.setPreferredSize(new Dimension(FIELD_SIZE.width + 100, 250)); // Lebar scrollPane sesuai form
+        scrollPane.setPreferredSize(new Dimension(400, 250)); // Limit width
         scrollPane.setBorder(BorderFactory.createTitledBorder(
                 BorderFactory.createLineBorder(UIStyles.BORDER_GRAY),
                 "Select Patients",


### PR DESCRIPTION
## Summary
- center login form with GridBagLayout
- use same layout approach in RegisterView
- limit auth form width to about 400px
- apply consistent padding

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684950c530d083288429287a86146454