### PR TITLE
Move logout link to sidebar

### DIFF
--- a/src/main/java/com/caremonitor/controller/AuthController.java
+++ b/src/main/java/com/caremonitor/controller/AuthController.java
@@ -90,19 +90,6 @@ public class AuthController {
         dashboardFrame.setMinimumSize(new Dimension(1000, 600));
         JPanel mainPanel = new JPanel(new BorderLayout());
 
-        JPanel headerPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
-        headerPanel.setBackground(Color.WHITE);
-        headerPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-
-        JButton logoutButton = new JButton("Logout");
-        logoutButton.setBackground(UIStyles.DANGER_RED);
-        logoutButton.setForeground(Color.WHITE);
-        logoutButton.setFocusPainted(false);
-        logoutButton.setBorderPainted(false);
-        logoutButton.setOpaque(true);
-        logoutButton.setCursor(new Cursor(Cursor.HAND_CURSOR));
-
-        headerPanel.add(logoutButton);
 
         SidebarPanel sidebarPanel = new SidebarPanel(user.getRole());
         CardLayout contentCardLayout = new CardLayout();
@@ -119,15 +106,13 @@ public class AuthController {
         contentPanel.add(dashboardView.getMainPanel(), "dashboard");
         contentPanel.add(healthHistoryView.getMainPanel(), "history");
         
-        setupNavigation(sidebarPanel, contentCardLayout, contentPanel, 
-                       dashboardView, healthHistoryView, criticalParametersView, 
+        setupNavigation(sidebarPanel, contentCardLayout, contentPanel,
+                       dashboardView, healthHistoryView, criticalParametersView,
                        dashboardFrame, user);
+        sidebarPanel.addLogoutListener(e -> logout(dashboardFrame, dashboardView));
         
-        mainPanel.add(headerPanel, BorderLayout.NORTH);
         mainPanel.add(sidebarPanel, BorderLayout.WEST);
         mainPanel.add(contentPanel, BorderLayout.CENTER);
-
-        logoutButton.addActionListener(e -> logout(dashboardFrame, dashboardView));
         
         dashboardFrame.setContentPane(mainPanel);
         

--- a/src/main/java/com/caremonitor/view/components/SidebarPanel.java
+++ b/src/main/java/com/caremonitor/view/components/SidebarPanel.java
@@ -41,8 +41,8 @@ public class SidebarPanel extends JPanel {
         if ("CAREGIVER".equals(userRole)) {
             criticalParametersLabel = createMenuLabel("Critical Parameters", false);
         }
-        
-        logoutLabel = createMenuLabel("Logout", false);
+
+        logoutLabel = createMenuLabel("Logout", false, UIStyles.SOFT_RED);
         logoutLabel.setForeground(UIStyles.DANGER_RED);
         
         activeLabel = healthDashboardLabel;
@@ -73,10 +73,15 @@ public class SidebarPanel extends JPanel {
         }
         
         add(Box.createVerticalGlue());
+        add(logoutLabel);
         add(Box.createRigidArea(new Dimension(0, 30)));
     }
-    
+
     private JLabel createMenuLabel(String text, boolean isActive) {
+        return createMenuLabel(text, isActive, UIStyles.HOVER_BLUE);
+    }
+
+    private JLabel createMenuLabel(String text, boolean isActive, Color hoverColor) {
         JLabel label = new JLabel("<html>" + text + "</html>");
         label.setFont(isActive ? UIStyles.ARIAL_BOLD_16 : UIStyles.ARIAL_PLAIN_16);
         label.setForeground(isActive ? UIStyles.LIGHT_BLUE : Color.WHITE);
@@ -94,10 +99,10 @@ public class SidebarPanel extends JPanel {
             public void mouseEntered(MouseEvent e) {
                 if (label != activeLabel) {
                     label.setOpaque(true);
-                    label.setBackground(UIStyles.HOVER_BLUE);
+                    label.setBackground(hoverColor);
                 }
             }
-            
+
             @Override
             public void mouseExited(MouseEvent e) {
                 if (label != activeLabel) {


### PR DESCRIPTION
## Summary
- tweak sidebar to show Logout at the bottom and support custom hover color
- remove top logout button from dashboard
- hook Logout label into existing logout logic

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849625c92e08328889fb1a82b27d868