### PR TITLE
Adjust split pane proportions

### DIFF
--- a/src/main/java/com/caremonitor/view/DashboardView.java
+++ b/src/main/java/com/caremonitor/view/DashboardView.java
@@ -61,7 +61,8 @@ public class DashboardView {
         JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         splitPane.setBorder(BorderFactory.createEmptyBorder(10, 20, 20, 20));
         splitPane.setDividerSize(4);
-        splitPane.setResizeWeight(1.0); // allow left panel to take remaining space
+        // Allocate roughly 70% of the width for patient cards
+        splitPane.setResizeWeight(0.7);
 
         JPanel patientsSection = new JPanel(new BorderLayout());
         patientsSection.setBackground(Color.WHITE);
@@ -103,9 +104,13 @@ public class DashboardView {
         alertsSection.add(alertsScrollPane, BorderLayout.CENTER);
 
         alertsSection.setPreferredSize(new Dimension(300, 0));
+        // Prevent alerts section from growing too large
+        alertsSection.setMaximumSize(new Dimension(400, Integer.MAX_VALUE));
 
         splitPane.setLeftComponent(patientsSection);
         splitPane.setRightComponent(alertsSection);
+        // Position divider so approximately 70% of the width is used by the patients section
+        splitPane.setDividerLocation(0.7);
 
         mainPanel.add(headerPanel, "dock north");
         mainPanel.add(splitPane, "grow");


### PR DESCRIPTION
## Summary
- tweak resize weight and divider location in `DashboardView` for better layout
- prevent alerts panel from overexpanding

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6849664c3300832894cbfb613ef1011d