### PR TITLE
Fix Dashboard card layout

### DIFF
--- a/src/main/java/com/caremonitor/view/DashboardView.java
+++ b/src/main/java/com/caremonitor/view/DashboardView.java
@@ -73,7 +73,7 @@ public class DashboardView {
 
         patientHeaderPanel.add(patientsLabel, BorderLayout.WEST);
 
-        patientsPanel = new JPanel(new GridLayout(0, 2, 20, 20));
+        patientsPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 20, 20));
         patientsPanel.setBackground(Color.WHITE);
         patientsPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
 


### PR DESCRIPTION
## Summary
- allow patient cards to keep natural size in DashboardView

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a80ae27ec8328a6cb3ed5c2ef908a